### PR TITLE
CU-865c1kkgr_bugCheck-No-more-reminders-during-this-billing-cycle-and-then-click-Upgrade-Now-to-jump-to-the-upgrade-plan-page-and-the-banner-should-not-be-displayed_Muhammad-Akif

### DIFF
--- a/airbyte-webapp/src/views/layout/Banners/SyncNotificationBanner/SyncNotificationBanner.tsx
+++ b/airbyte-webapp/src/views/layout/Banners/SyncNotificationBanner/SyncNotificationBanner.tsx
@@ -41,18 +41,28 @@ const CrossBtn = styled.button`
 
 export const SyncNotificationBanner: React.FC<IProps> = ({ usagePercentage, onBillingPage }) => {
   const [ignoreModal, setIgnoreModal] = useState<boolean>(false);
+  const [bannerVisibility, setBannerVisibility] = useState<boolean>(true);
 
-  return (
-    <>
-      <Banner className={styles.banner}>
-        <Text>
-          <FormattedMessage id="usage.notification.banner.usageText" values={{ percentage: usagePercentage }} />
-        </Text>
-        <CrossBtn onClick={() => setIgnoreModal(true)}>
-          <CrossIcon />
-        </CrossBtn>
-      </Banner>
-      {ignoreModal && <IgnoreNotificationModal onClose={() => setIgnoreModal(false)} onBillingPage={onBillingPage} />}
-    </>
-  );
+  if (bannerVisibility) {
+    return (
+      <>
+        <Banner className={styles.banner}>
+          <Text>
+            <FormattedMessage id="usage.notification.banner.usageText" values={{ percentage: usagePercentage }} />
+          </Text>
+          <CrossBtn onClick={() => setIgnoreModal(true)}>
+            <CrossIcon />
+          </CrossBtn>
+        </Banner>
+        {ignoreModal && (
+          <IgnoreNotificationModal
+            setBannerVisibility={setBannerVisibility}
+            onClose={() => setIgnoreModal(false)}
+            onBillingPage={onBillingPage}
+          />
+        )}
+      </>
+    );
+  }
+  return null;
 };

--- a/airbyte-webapp/src/views/layout/Banners/SyncNotificationBanner/components/IgnoreNotificationModal.tsx
+++ b/airbyte-webapp/src/views/layout/Banners/SyncNotificationBanner/components/IgnoreNotificationModal.tsx
@@ -8,6 +8,7 @@ import { Separator } from "components/Separator";
 import { useAsyncActions } from "services/notificationSetting/NotificationSettingService";
 
 interface IProps {
+  setBannerVisibility?: React.Dispatch<React.SetStateAction<boolean>>;
   onClose?: () => void;
   onBillingPage: () => void;
 }
@@ -65,16 +66,18 @@ const CheckboxText = styled.div`
   user-select: none;
 `;
 
-export const IgnoreNotificationModal: React.FC<IProps> = ({ onClose, onBillingPage }) => {
+export const IgnoreNotificationModal: React.FC<IProps> = ({ setBannerVisibility, onClose, onBillingPage }) => {
   const { onIgnoreNotifications } = useAsyncActions();
 
   const [noPrompt, setNoPrompt] = useState<boolean>(false);
   const [ignoreLoading, setIgnoreLoading] = useState<boolean>(false);
+  const [upgradeLoading, setUpgradeLoading] = useState<boolean>(false);
   const onIgnore = () => {
     setIgnoreLoading(true);
     onIgnoreNotifications({ noPrompt })
       .then(() => {
         setIgnoreLoading(false);
+        setBannerVisibility?.(false);
         onClose?.();
       })
       .catch(() => {
@@ -83,8 +86,17 @@ export const IgnoreNotificationModal: React.FC<IProps> = ({ onClose, onBillingPa
   };
 
   const onUpgrade = () => {
-    onBillingPage();
-    onClose?.();
+    setUpgradeLoading(true);
+    onIgnoreNotifications({ noPrompt })
+      .then(() => {
+        setUpgradeLoading(false);
+        setBannerVisibility?.(false);
+        onBillingPage();
+        onClose?.();
+      })
+      .catch(() => {
+        setUpgradeLoading(false);
+      });
   };
   return (
     <Modal size="sm" onClose={onClose}>
@@ -102,7 +114,7 @@ export const IgnoreNotificationModal: React.FC<IProps> = ({ onClose, onBillingPa
             <ModalButton size="lg" secondary onClick={onIgnore} isLoading={ignoreLoading}>
               <FormattedMessage id="ignore.notification.modal.ignoreBtnText" />
             </ModalButton>
-            <ModalButton size="lg" onClick={onUpgrade}>
+            <ModalButton size="lg" onClick={onUpgrade} isLoading={upgradeLoading}>
               <FormattedMessage id="ignore.notification.modal.upgradeBtnText" />
             </ModalButton>
           </ButtonsContainer>

--- a/airbyte-webapp/src/views/layout/MainView/MainView.tsx
+++ b/airbyte-webapp/src/views/layout/MainView/MainView.tsx
@@ -143,9 +143,10 @@ const MainView: React.FC = (props) => {
         <ResourceNotFoundErrorBoundary errorComponent={<StartOverErrorView />}>
           <React.Suspense fallback={<LoadingPage />}>
             <UpgradePlanBanner onBillingPage={onBillingPage} />
-            {usage !== undefined && usagePercentage > 0 && usagePercentage < 100 && (
+            {/* {usage !== undefined && usagePercentage > 0 && usagePercentage < 100 && (
               <SyncNotificationBanner usagePercentage={usagePercentage} onBillingPage={onBillingPage} />
-            )}
+            )} */}
+            <SyncNotificationBanner usagePercentage={usagePercentage} onBillingPage={onBillingPage} />
             {usage !== undefined && usagePercentage >= 100 && <BillingWarningBanner onBillingPage={onBillingPage} />}
             {props.children}
           </React.Suspense>


### PR DESCRIPTION
Banner closed after click to upgrade and ignore buttons