### PR TITLE
CU-860q6npqu_Remove-Store-name-field-in-Amazon-ads-and-make-it-not-mandatory_Nick

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/common.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/common.py
@@ -75,7 +75,10 @@ class BasicAmazonAdsStream(Stream, ABC):
 
     def __init__(self, config: Mapping[str, Any], profiles: List[Profile] = None):
         self._profiles = profiles or []
-        self._source_name = config["source_name"]
+        if "source_name" in config:
+            self._source_name = config["source_name"]
+        else:
+            self._source_name = ""
         self._client_id = config["client_id"]
         self._url = URL_MAPPING[config["region"]]
 


### PR DESCRIPTION
made source_name optional